### PR TITLE
renaming can0 to emuccan0 in systemd service.

### DIFF
--- a/emuccan.service
+++ b/emuccan.service
@@ -12,9 +12,9 @@ EnvironmentFile=/etc/default/emuccan
 # emucd is hardcoded(!) to use /ttyACM[0-9] which is terrible, so we have
 # created a udev rule to put it at /dev/ttyACM9 interface. This is
 # terrible, but works for now.
-ExecStart=/usr/bin/emucd_64 -s${EMUCCAN_SPEED} /dev/ttyACM9 can0 can1
-ExecStartPost=/sbin/ip link set can0 up qlen 1000
-ExecStartPost=/sbin/ip link set can1 up qlen 1000
+ExecStart=/usr/bin/emucd_64 -s${EMUCCAN_SPEED} /dev/ttyACM9 emuccan0 emuccan1
+ExecStartPost=/sbin/ip link set emuccan0 up qlen 1000
+ExecStartPost=/sbin/ip link set emuccan1 up qlen 1000
 ExecStop=/usr/bin/pkill -2 emucd_64
 Restart=always
 RestartSec=5


### PR DESCRIPTION
I think this is part of the renaming suggested by @seebq in https://app.shortcut.com/greenzie/story/23488/the-computer-has-disconnected-try-the-reboot-button-from-the-controls-tab-if-this-issue-persists-please-text-or-call-greenzie .
