### PR TITLE
Use /dev/ttyCAN0 instead of /dev/ttyACM9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if (IS_DIRECTORY /etc/default)
 endif()
 
 # Increment this for each rebuild (i.e. new kernel) using the same upstream ver
-set(CPACK_DEBIAN_PACKAGE_RELEASE "2")
+set(CPACK_DEBIAN_PACKAGE_RELEASE "3")
 
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_CONTACT "cbq@greenzie.com")

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ root@host# emucd -s6 /dev/ttyACM0  (250 KBPS on both channel)
 root@host# emucd -s45 /dev/ttyACM0 (100 KBPS on ch1, 125 KBPS on ch2)
 ```
 
-## Trubleshooting
+## Troubleshooting
 
 If the can device did not show up after 'emucd' is executed. Please check
 your system log to see if there is any error message reported by emuccan
@@ -53,11 +53,14 @@ root@host# emucd -F -s6 /dev/ttyACM0
 There cannot be two EMUCD daemon running with same TTY device. You must
 kill the previous one before running a new one on same device.
 
-## A note on /dev/tty devices
+## A note on device names
 
-Unfortunately, emucd_64 is hardcoded(!) to use a /ttyACM[0-9] which is terrible,
-so you must create a udev rule to put it at something hardcoded, in this case
-we chose /dev/ttyACM9 interface. This is terrible, but works for now.
+Unfortunately, emucd_64 is hardcoded(!) to only accept certain device names
+defined in an extern variable called comports (search inside
+lib_emuc2_64.a object). Yup. Go figure. So we hardcode it to `/dev/ttyCAN0`
+for now. Even worse, we used to use /dev/ttyACM9 but that was causing issues
+with un-plugging and replugging enough tty devices that our symlink was
+interferring with the dynamic kernel defined names (on the 10th replug).
 
 ## Debian and System Install
 

--- a/emuccan.service
+++ b/emuccan.service
@@ -9,10 +9,16 @@ After=dev-ttyCAN0.device
 Type=forking
 # Load Environment variables for speed
 EnvironmentFile=/etc/default/emuccan
+# The InnoDisk EMUC start.sh and end.sh scripts do modprobe and rmmod as part
+# of the starting and stopping process. And unfortunately it works. If you do
+# not rmmod and modprobe on a restart (and sleep), it fails to restart.
+ExecStartPre=-/usr/sbin/modprobe emuc2socketcan
 ExecStart=/usr/bin/emucd_64 -s${EMUCCAN_SPEED} /dev/ttyCAN0 can0 can1
 ExecStartPost=/sbin/ip link set can0 up qlen 1000
 ExecStartPost=/sbin/ip link set can1 up qlen 1000
 ExecStop=/usr/bin/pkill -2 emucd_64
+ExecStop=/usr/bin/sleep 0.2
+ExecStop=-/usr/sbin/rmmod emuc2socketcan
 Restart=always
 RestartSec=5
 

--- a/emuccan.service
+++ b/emuccan.service
@@ -1,18 +1,15 @@
 [Unit]
 Description=EMUC-B202 CAN Bus SocketCAN daemon and interfaces
-# We need to wait until /dev/ttyACM9 comes online, see udev rule for details
-BindsTo=dev-ttyACM9.device
-After=dev-ttyACM9.device
+# We need to wait until /dev/ttyCAN0 comes online, see udev rule for details
+BindsTo=dev-ttyCAN0.device
+After=dev-ttyCAN0.device
 
 [Service]
 # emucd daemonizes itself (i.e. forks)
 Type=forking
 # Load Environment variables for speed
 EnvironmentFile=/etc/default/emuccan
-# emucd is hardcoded(!) to use /ttyACM[0-9] which is terrible, so we have
-# created a udev rule to put it at /dev/ttyACM9 interface. This is
-# terrible, but works for now.
-ExecStart=/usr/bin/emucd_64 -s${EMUCCAN_SPEED} /dev/ttyACM9 can0 can1
+ExecStart=/usr/bin/emucd_64 -s${EMUCCAN_SPEED} /dev/ttyCAN0 can0 can1
 ExecStartPost=/sbin/ip link set can0 up qlen 1000
 ExecStartPost=/sbin/ip link set can1 up qlen 1000
 ExecStop=/usr/bin/pkill -2 emucd_64

--- a/emuccan.udev
+++ b/emuccan.udev
@@ -1,6 +1,12 @@
 # Unfortunately, we cannot use a symlink fancy name because the library that
-# uses this rule is hardcoded to only accept /dev/ttyACM[0-9]. Yup. Go figure.
-# So we hardcode it to /dev/ttyACM9. Sigh. If we had our way, it would be named
+# uses this rule is hardcoded to only accept certain device names defined in
+# an extern variable called comports (search inside lib_emuc2_64.a object).
+# Yup. Go figure. So we hardcode it to /dev/ttyCAN0 for now.
+# Even worse, we used to use /dev/ttyACM9 but that was causing issues with
+# un-plugging and replugging enough tty devices that our symlink was
+# interferring with the dynamic kernel defined names (on the 10th replug).
+# Sigh. If we had our way, it would be named
 # /dev/greenzie_emuc_b201_canbus but we can't have it our way.
+# So /dev/tty/CAN0 it is for now:
 SUBSYSTEM=="tty", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="0205", \
-  MODE="0660", GROUP="dialout", SYMLINK+="ttyACM9", TAG+="systemd"
+  MODE="0660", GROUP="dialout", SYMLINK+="ttyCAN0", TAG+="systemd"


### PR DESCRIPTION
Because we were using /dev/ttyACM9 if you unplug and replug in enough tty devices, they eventually take that device name.  It's reserved and the symlink apparently gets overridden or linux doesn't like you using that device name.

Just ask @AGummyBear how many times he had to manually unplug/replug devices (luckily he has per port power USB control and was able to do it via software). 

Sadly, the software still requires one of these reserved names instead of a fancy unique udev name or by serial or some other more modern approach.

I tested this briefly by hardcoding the change in the udev rule on a machine and the emucd_64 binary worked:

```
sudo /usr/bin/emucd_64 -s6 /dev/ttyCAN0 can0 can1

$ ps auxww | grep emuc
root        3646  0.0  0.0   4004   132 ?        Ss   21:11   0:00 /usr/bin/emucd_64 -s6 /dev/ttyCAN0 can0 can1
```

This should minor version bump.

Would like to test installing this manual deb on a machine to make sure that it updates the udev rule appropriately.

I'm nervous the Debian installation won't allow overwriting this config file.